### PR TITLE
Feature/#108 fix member control

### DIFF
--- a/src/main/java/ybe/mini/travelserver/domain/member/controller/MemberController.java
+++ b/src/main/java/ybe/mini/travelserver/domain/member/controller/MemberController.java
@@ -45,8 +45,14 @@ public class MemberController {
 
     @PreAuthorize(HAS_ROLE_USER)
     @PatchMapping("/mypage")
-    public ResponseDto<MypageUpdateResponse> updateMember(@RequestBody @Valid MypageUpdateRequest mypageUpdateRequest) {
-        MypageUpdateResponse mypageUpdateResponse = memberService.updateMemberProfile(mypageUpdateRequest);
+    public ResponseDto<MypageUpdateResponse> updateMember(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody @Valid MypageUpdateRequest mypageUpdateRequest
+    ) {
+        MypageUpdateResponse mypageUpdateResponse = memberService.updateMemberProfile(
+                principalDetails,
+                mypageUpdateRequest
+        );
 
         return new ResponseDto<>(HttpStatus.OK.value(), mypageUpdateResponse);
     }

--- a/src/main/java/ybe/mini/travelserver/domain/member/dto/MypageDeleteRequest.java
+++ b/src/main/java/ybe/mini/travelserver/domain/member/dto/MypageDeleteRequest.java
@@ -1,25 +1,13 @@
 package ybe.mini.travelserver.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import ybe.mini.travelserver.domain.member.entity.Member;
 
 import java.io.Serializable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record MypageDeleteRequest(
         @Email
-        String email,
-        @NotBlank
-        String password
+        String email
 ) implements Serializable {
-    public Member toEntity() {
-        return Member.builder()
-                .email(email)
-                .password(password)
-                .build();
-    }
 }

--- a/src/main/java/ybe/mini/travelserver/domain/member/dto/MypageDeleteResponse.java
+++ b/src/main/java/ybe/mini/travelserver/domain/member/dto/MypageDeleteResponse.java
@@ -1,8 +1,6 @@
 package ybe.mini.travelserver.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import ybe.mini.travelserver.domain.member.entity.Member;
@@ -14,12 +12,12 @@ public record MypageDeleteResponse(
         @Email
         String email,
         @NotBlank
-        String password
+        String name
 ) implements Serializable {
     public static MypageDeleteResponse fromEntity(Member member) {
         return new MypageDeleteResponse(
                 member.getEmail(),
-                member.getPassword()
+                member.getName()
         );
     }
 }

--- a/src/main/java/ybe/mini/travelserver/domain/member/dto/MypageUpdateRequest.java
+++ b/src/main/java/ybe/mini/travelserver/domain/member/dto/MypageUpdateRequest.java
@@ -1,28 +1,15 @@
 package ybe.mini.travelserver.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import ybe.mini.travelserver.domain.member.entity.Member;
 
 import java.io.Serializable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record MypageUpdateRequest(
-        @Email
-        String email,
         @NotBlank
         String password,
         @NotBlank
         String name
 ) implements Serializable {
-    public Member toEntity() {
-        return Member.builder()
-                .email(email)
-                .password(password)
-                .name(name)
-                .build();
-    }
 }

--- a/src/main/java/ybe/mini/travelserver/domain/member/exception/CanNotControlOtherMembersData.java
+++ b/src/main/java/ybe/mini/travelserver/domain/member/exception/CanNotControlOtherMembersData.java
@@ -1,0 +1,4 @@
+package ybe.mini.travelserver.domain.member.exception;
+
+public class CanNotControlOtherMembersData extends RuntimeException{
+}

--- a/src/main/java/ybe/mini/travelserver/domain/member/exception/MemberErrorMessage.java
+++ b/src/main/java/ybe/mini/travelserver/domain/member/exception/MemberErrorMessage.java
@@ -11,7 +11,9 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @AllArgsConstructor
 public enum MemberErrorMessage implements ErrorMessage {
     MEMBER_ALREADY_EXIST(BAD_REQUEST, "회원이 이미 있습니다"),
-    MEMBER_NOT_FOUND(BAD_REQUEST, "없는 회원입니다");
+    MEMBER_NOT_FOUND(BAD_REQUEST, "없는 회원입니다"),
+    CAN_NOT_CONTROL_OTHER_MEMBERS_DATA(BAD_REQUEST, "다른 회원의 정보를 제어할 수 없습니다");
+
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/ybe/mini/travelserver/domain/member/exception/MemberExceptionHandler.java
+++ b/src/main/java/ybe/mini/travelserver/domain/member/exception/MemberExceptionHandler.java
@@ -6,8 +6,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import ybe.mini.travelserver.global.exception.ProblemDetailCreator;
 
-import static ybe.mini.travelserver.domain.member.exception.MemberErrorMessage.MEMBER_ALREADY_EXIST;
-import static ybe.mini.travelserver.domain.member.exception.MemberErrorMessage.MEMBER_NOT_FOUND;
+import static ybe.mini.travelserver.domain.member.exception.MemberErrorMessage.*;
 
 @RestControllerAdvice
 public class MemberExceptionHandler extends ProblemDetailCreator<MemberErrorMessage> {
@@ -24,4 +23,10 @@ public class MemberExceptionHandler extends ProblemDetailCreator<MemberErrorMess
     public ProblemDetail handleMemberNotFoundException(HttpServletRequest request) {
         return createProblemDetail(MEMBER_NOT_FOUND, request);
     }
+
+    @ExceptionHandler(CanNotControlOtherMembersData.class)
+    public ProblemDetail handleCanNotUpdateWithOtherValidTokens(HttpServletRequest request) {
+        return createProblemDetail(CAN_NOT_CONTROL_OTHER_MEMBERS_DATA, request);
+    }
+
 }

--- a/src/test/java/ybe/mini/travelserver/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/ybe/mini/travelserver/domain/member/controller/MemberControllerTest.java
@@ -72,15 +72,18 @@ class MemberControllerTest implements DummyMemberDTO, DummyPrincipal {
     @DisplayName("회원정보 수정 테스트")
     void testUpdateMember() {
         // given
-        given(memberService.updateMemberProfile(any())).willReturn(dummyMypageUpdateResponse());
+        given(memberService.updateMemberProfile(any(),any())).willReturn(dummyMypageUpdateResponse());
 
         // when
-        var actual = memberController.updateMember(dummyMypageUpdateRequest());
+        var actual = memberController.updateMember(
+                dummyPrincipalDetails(),
+                dummyMypageUpdateRequest()
+        );
 
         // then
         var expected = new ResponseDto<>(200, dummyMypageUpdateResponse());
         assertEquals(expected, actual);
-        then(memberService).should().updateMemberProfile(any());
+        then(memberService).should().updateMemberProfile(any(), any());
     }
 
     @Test

--- a/src/test/java/ybe/mini/travelserver/domain/member/dummy/DummyMemberDTO.java
+++ b/src/test/java/ybe/mini/travelserver/domain/member/dummy/DummyMemberDTO.java
@@ -49,7 +49,6 @@ public interface DummyMemberDTO extends DummyMember {
     default MypageUpdateRequest dummyMypageUpdateRequest() {
         Member member2 = dummyMemberUpdatedProfile();
         return new MypageUpdateRequest(
-                member2.getEmail(),
                 member2.getPassword(),
                 member2.getName()
         );
@@ -67,8 +66,7 @@ public interface DummyMemberDTO extends DummyMember {
     default MypageDeleteRequest dummyMypageDeleteRequest() {
         Member member = dummyMember();
         return new MypageDeleteRequest(
-                member.getEmail(),
-                member.getPassword()
+                member.getEmail()
         );
     }
 
@@ -76,7 +74,7 @@ public interface DummyMemberDTO extends DummyMember {
         Member member = dummyMember();
         return new MypageDeleteResponse(
                 member.getEmail(),
-                member.getPassword()
+                member.getName()
         );
     }
 }

--- a/src/test/java/ybe/mini/travelserver/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/ybe/mini/travelserver/domain/member/service/MemberServiceTest.java
@@ -101,7 +101,10 @@ class MemberServiceTest implements DummyMemberDTO, DummyPrincipal {
         given(passwordEncoder.encode(newPassword)).willReturn(bcrptyedNewPassword);
 
         // when
-        var actual = memberService.updateMemberProfile(dummyMypageUpdateRequest());
+        var actual = memberService.updateMemberProfile(
+                dummyPrincipalDetails(),
+                dummyMypageUpdateRequest()
+        );
 
         // then
         var expected = dummyMypageUpdateResponse();
@@ -116,7 +119,10 @@ class MemberServiceTest implements DummyMemberDTO, DummyPrincipal {
         given(memberRepository.findByEmail(email)).willReturn(Optional.ofNullable(dummyMember()));
 
         // when
-        var actual = memberService.deleteMemberProfile(dummyPrincipalDetails(), dummyMypageDeleteRequest());
+        var actual = memberService.deleteMemberProfile(
+                dummyPrincipalDetails(),
+                dummyMypageDeleteRequest()
+        );
 
         // then
         var expected = dummyMypageDeleteResponse();


### PR DESCRIPTION
## 변경사항

A 회원이 B 회원 정보 제어할 수 있던 문제 해결

### Issue Link - #108 

-----

## 체크리스트

리뷰 요청 전에 확인해야 할 사항들을 나열해주세요.

- [x] 공격자가 다른 회원정보를 제어하지 못하게 막았나요?
- [x] 해당 변경으로 인해 회원 조회, 수정, 삭제 기능에 영향을 끼치진 않았나요?
- [x] 핵심 기능에 대해 충분한 테스트를 수행했나요?

-----

## 참고

더이상 의도적으로 다른 회원 정보를 제어할 수 없음

![image](https://github.com/Mini-Team-6/Mini-Team-6-Backend/assets/26517061/9921aa7f-d8ed-469e-b54a-9e6939652c08)

테스트용 회원 정보 2개

![스크린샷 2023-11-29 165700](https://github.com/Mini-Team-6/Mini-Team-6-Backend/assets/26517061/ce441e36-904f-4768-aa3d-49e824d8bc39)

임의로 다른 회원 정보 변경 시도하면 자기꺼에 변경되게 함. email 값 주입해도 받아주지 않음

![스크린샷 2023-11-29 165751](https://github.com/Mini-Team-6/Mini-Team-6-Backend/assets/26517061/73943b61-d43c-4280-9753-0b4bba9f0d44)


DB 결과. 다른 회원 정보가 바뀌지 않음

![스크린샷 2023-11-29 165817](https://github.com/Mini-Team-6/Mini-Team-6-Backend/assets/26517061/f2b6e3f6-d065-495d-82c9-e059fbda37cb)


올바르게 자신의 데이터 변경할 수 있음

![스크린샷 2023-11-29 170226](https://github.com/Mini-Team-6/Mini-Team-6-Backend/assets/26517061/fc309f55-e4ab-477a-b5a0-73b9ebb34ad7)

![스크린샷 2023-11-29 170232](https://github.com/Mini-Team-6/Mini-Team-6-Backend/assets/26517061/1a984663-0472-495c-a662-8b3d982f28a8)


